### PR TITLE
Fix LootCard and ReactionBar CSS

### DIFF
--- a/frontend/src/components/loot-showcase/LootCard.tsx
+++ b/frontend/src/components/loot-showcase/LootCard.tsx
@@ -109,7 +109,7 @@ export default function LootCard({
               <span
                 key={emoji}
                 title={data.accounts.join("\n")}
-                className="flex items-center gap-1 h-[24px] w-[46px] rounded-full bg-zinc-800/90 hover:bg-zinc-800/60 hover:scale-125 transition-transform text-gray-300 px-2 py-0.5 cursor-pointer"
+                className="flex items-center gap-1 rounded-full bg-zinc-800/90 hover:bg-zinc-800/60 hover:scale-125 transition-transform text-gray-300 px-2 py-0.5 cursor-pointer"
                 onClick={() => handleReaction(item.id, emoji)}
               >
                 <span>{emoji}</span>

--- a/frontend/src/components/loot-showcase/ReactionBar.tsx
+++ b/frontend/src/components/loot-showcase/ReactionBar.tsx
@@ -26,7 +26,7 @@ export default function ReactionBar({
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   return (
-    <div className="group absolute bottom-2 right-2 z-10 flex flex-row-reverse gap-0 opacity-0 group-hover:opacity-100 rounded-full bg-zinc-800/90 px-2 py-1 shadow-md">
+    <div className="group absolute bottom-2 right-2 z-10 flex flex-row-reverse opacity-0 group-hover:opacity-100 rounded-full bg-zinc-800/90 px-2 py-1 shadow-md">
       {/* Toggle Button */}
       <button
         onClick={() => setIsCollapsed(!isCollapsed)}


### PR DESCRIPTION
Fix the spacing, moved the SmileyPlus to the right side when ReactionBar is toggled. General styling to adheer to theme.